### PR TITLE
Include doctype in IE8 example to make JSON work

### DIFF
--- a/ch02/listing-2.6/index.html
+++ b/ch02/listing-2.6/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <body onload="loadPhotos();">
 <div id="photos"></div>


### PR DESCRIPTION
IE8 only makes JSON object available if a DOCTYPE is present.
See http://stackoverflow.com/questions/4715373/json-object-undefined-in-internet-explorer-8-dom for reference
